### PR TITLE
Fixed typo bug with createPersistentIndex - missing letter s

### DIFF
--- a/lib/Orango.js
+++ b/lib/Orango.js
@@ -462,7 +462,7 @@ class Orango extends EventEmitter {
           promises.push(collection.createFulltextIndex(item.fields, item.opts))
           break
         case SCHEMA.INDEX.PERSISTENT:
-          promises.push(collection.createPersitentIndex(item.fields, item.opts))
+          promises.push(collection.createPersistentIndex(item.fields, item.opts))
           break
       }
     }


### PR DESCRIPTION
There was a bug in the code related to a simple typo.

Should be: `collection.createPersistentIndex` 
Was written as `collection.createPersitentIndex`

Simple fix.

Pulling for review.

This references the following Issue: https://github.com/roboncode/orango/issues/74